### PR TITLE
Added small http server to manage vetting of grievances

### DIFF
--- a/manage_grievances/manage_grievances.py
+++ b/manage_grievances/manage_grievances.py
@@ -1,0 +1,90 @@
+import os
+import sqlite3
+import gspread
+from oauth2client.service_account import ServiceAccountCredentials
+from flask import Flask, request, session, g, redirect, url_for, abort, render_template, flash
+
+#create our little application :)
+app = Flask(__name__)
+app.config.from_object(__name__)
+
+#Load default config and override config from an environment variable
+app.config.update(dict(
+    SECRET_KEY='',
+    USERNAME='admin',
+    PASSWORD='default',
+    GOOGLE_SHEET_KEY='',
+    JSON_KEYFILE_NAME='',
+    GTPATH='FILL/hopper/grievances_to_air.txt',
+    ))
+app.config.from_envvar('FLASKR_SETTINGS', silent=True)
+
+
+def get_worksheet():
+    scope = ['https://spreadsheets.google.com/feeds']
+    credentials = ServiceAccountCredentials.from_json_keyfile_name(app.config['JSON_KEYFILE_NAME'],scope);
+    gc = gspread.authorize(credentials)
+    sheet = gc.open_by_key(app.config['GOOGLE_SHEET_KEY'])
+    worksheet = sheet.get_worksheet(0)
+    return worksheet
+
+
+@app.route('/')
+def show_entries():
+    worksheet = get_worksheet()
+    rows =  worksheet.get_all_values()
+    return render_template('show_entries.html', rows=rows)
+
+@app.route('/ignore', methods=['GET'])
+def ignore_entry():
+    if not session.get('logged_in'):
+        abort(401)
+    if not request.args.get('row'):
+        flash('No entry specified')
+        return redirect(url_for('show_entries'))
+    row = request.args.get('row')
+    worksheet = get_worksheet()
+    worksheet.update_cell(row,3, 'I')
+    flash('Entry was ignored.')
+    return redirect(url_for('show_entries'))
+
+
+@app.route('/approve', methods=['GET'])
+def approve_entry():
+    if not session.get('logged_in'):
+        abort(401)
+    if not request.args.get('row'):
+        flash('No entry specified')
+        return redirect(url_for('show_entries'))
+    
+    row = request.args.get('row')
+    worksheet = get_worksheet()
+    cell = worksheet.cell(row,2)
+    with open(app.config['GTPATH'], "a") as appFile:
+        appFile.write(cell.value + "\n")
+
+    worksheet.update_cell(row,3, 'A')
+
+    flash('New entry was successfully posted')
+    return redirect(url_for('show_entries'))
+
+@app.route('/login', methods=['GET', 'POST'])
+def login():
+    error = None
+    if request.method == 'POST':
+        if request.form['username'] != app.config['USERNAME']:
+            error = 'Invalid username or password'
+        elif request.form['password'] != app.config['PASSWORD']:
+            error = 'Invalid username or password'
+        else:
+            session['logged_in'] = True
+            flash('You were logged in')
+            return redirect(url_for('show_entries'))
+    return render_template('login.html', error=error)
+
+@app.route('/logout')
+def logout():
+    session.pop('logged_in', None)
+    flash('You were logged out')
+    return redirect(url_for('show_entries'))
+

--- a/manage_grievances/static/ie10-viewport-bug-workaround.css
+++ b/manage_grievances/static/ie10-viewport-bug-workaround.css
@@ -1,0 +1,13 @@
+/*!
+ * IE10 viewport hack for Surface/desktop Windows 8 bug
+ * Copyright 2014-2015 Twitter, Inc.
+ * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
+ */
+
+/*
+ * See the Getting Started docs for more information:
+ * http://getbootstrap.com/getting-started/#support-ie10-width
+ */
+@-ms-viewport     { width: device-width; }
+@-o-viewport      { width: device-width; }
+@viewport         { width: device-width; }

--- a/manage_grievances/static/ie10-viewport-bug-workaround.js
+++ b/manage_grievances/static/ie10-viewport-bug-workaround.js
@@ -1,0 +1,23 @@
+/*!
+ * IE10 viewport hack for Surface/desktop Windows 8 bug
+ * Copyright 2014-2015 Twitter, Inc.
+ * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
+ */
+
+// See the Getting Started docs for more information:
+// http://getbootstrap.com/getting-started/#support-ie10-width
+
+(function () {
+  'use strict';
+
+  if (navigator.userAgent.match(/IEMobile\/10\.0/)) {
+    var msViewportStyle = document.createElement('style')
+    msViewportStyle.appendChild(
+      document.createTextNode(
+        '@-ms-viewport{width:auto!important}'
+      )
+    )
+    document.querySelector('head').appendChild(msViewportStyle)
+  }
+
+})();

--- a/manage_grievances/static/navbar-static-top.css
+++ b/manage_grievances/static/navbar-static-top.css
@@ -1,0 +1,7 @@
+body {
+    min-height: 200px;
+}
+
+.navbar-static-top {
+    margin-bottom: 19px;
+}

--- a/manage_grievances/static/signin.css
+++ b/manage_grievances/static/signin.css
@@ -1,0 +1,40 @@
+body {
+    padding-bottom: 40px;
+    background-color: #eee;
+}
+
+.form-signin {
+    max-width: 330px;
+    padding: 15px;
+    margin: 0 auto;
+}
+.form-signin .form-signin-heading,
+.form-signin .checkbox {
+    margin-bottom: 10px;
+}
+.form-signin .checkbox {
+    font-weight: normal;
+}
+.form-signin .form-control {
+    position: relative;
+    height: auto;
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+    padding: 10px;
+    font-size: 16px;
+}
+.form-signin .form-control:focus {
+    z-index: 2;
+}
+.form-signin input[type="email"] {
+    margin-bottom: -1px;
+    border-bottom-right-radius: 0;
+    border-bottom-left-radius: 0;
+}
+.form-signin input[type="password"] {
+    margin-bottom: 10px;
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+}
+

--- a/manage_grievances/templates/layout.html
+++ b/manage_grievances/templates/layout.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<head>
+<title>lis_grievances</title>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="">
+    <meta name="author" content="">
+    <link rel="icon" href="../../favicon.ico">
+    <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='navbar-static-top.css') }}">
+    <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='style.css') }}">
+    <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='ie10-viewport-bug-workaround.css') }}">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+    <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
+     <!--[if lt IE 9]>
+     <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
+     <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+     <![endif]--> 
+    
+    
+    {% block head %} {% endblock %}
+</head> 
+<body>
+    <nav class="navbar navbar-default navbar-static-top">
+        <div class="container">
+            <div class="navbar-header">
+                <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
+                    <span class="sr-only">Toggle navigation</span>
+                    <span class="icon-bar"></span>
+                    <span class="icon-bar"></span>
+                    <span class="icon-bar"></span>
+                </button>
+                <a class="navbar-brand" href="/">lis_grievances</a>
+            </div>
+            <div id="navbar" class="navbar-collapse collapse">
+                <ul class="nav navbar-nav navbar-right">
+                {% if not session.logged_in %}
+                <li> <a href="{{ url_for('login') }}">Log in</a> </li>
+                {% else %}
+                <li> <a href="{{ url_for('logout') }}">Log out</a></li>
+                {% endif %}
+                </ul> 
+            </div>
+        </div>
+    </nav>
+    <div class="container">
+    {% for message in get_flashed_messages() %}
+        <div class="alert alert-info alert-dismissible" role="alert">
+            <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button> 
+            {{ message }}
+        </div>
+    {% endfor %}
+    {% block body %}{% endblock %}
+    </div>
+<!-- Latest compiled and minified JavaScript -->
+ <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+<script src="{{ url_for('static', filename='ie10-viewport-bug-workaround.js') }}"></script>
+<body>

--- a/manage_grievances/templates/login.html
+++ b/manage_grievances/templates/login.html
@@ -1,0 +1,24 @@
+{% extends "layout.html" %}
+{% block head %}
+<link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='signin.css') }}">
+{% endblock %}
+{% block body %}
+    <div class="container">
+        {% if error %}
+            <div class="alert alert-danger alert-dismissible" role="alert">
+                <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button> 
+                <strong>Error:</strong> {{ error }}
+            </div>
+        {% endif %}
+    <form action="{{ url_for('login') }}" class="form-signin"  method="post">
+        <h2 class="form-signin-heading">Please sign in</h2>     
+        <label for="username" class="sr-only">Username</label>
+        <input type="text" name="username" class="form-control" placeholder="Username" required autofocus>
+        <label for="password" class="sr-only">Password</label>
+        <input type=password name=password class="form-control" placeholder="Password" required>
+        
+        <button class="btn btn-lg btn-primary btn-block" type="submit">Sign in</button>
+    </form>
+    </div>
+{% endblock %}
+

--- a/manage_grievances/templates/show_entries.html
+++ b/manage_grievances/templates/show_entries.html
@@ -1,0 +1,24 @@
+{% extends "layout.html" %}
+{% block body %}
+    {% if session.logged_in %}
+        <table class="table">
+            <tr><th>Row#</th><th>Date</th><th>Tweet</th><th>Action</th>
+        {% for cols in rows %}
+          {% if cols|length < 3 or cols[2]|default("") == "" %}
+            <tr>
+                <td>{{ loop.index }}</td> 
+            <td>{{cols[0]}}</td>
+            <td>{{cols[1]}}</td>
+            <td>
+                <a class="btn btn-default" href="approve?row={{loop.index}}">Approve</a>
+                <a class="btn btn-default" href="ignore?row={{loop.index}}">Decline</a>
+            </td> 
+            </tr>
+          {% endif %}
+            {% else %}
+            <tr><td>Nothing</td></tr>
+        {% endfor %}
+        </table>
+    {% endif %}
+{% endblock %}
+


### PR DESCRIPTION
Added Flask app to manage/vett grievances
Running the server:
$ export FLASK_APP=manage_grievances.py
$ flask run
more info:  http://flask.pocoo.org/docs/0.11/quickstart/#quickstart

Info on getting google api oauth credentials for gspread
http://gspread.readthedocs.io/en/latest/oauth2.html

Things to set in manage_grievances.py:
app.config.update(dict(
    SECRET_KEY='',
    USERNAME='admin',
    PASSWORD='default',
    GOOGLE_SHEET_KEY='',
    JSON_KEYFILE_NAME='',
    GTPATH='FILL/hopper/grievances_to_air.txt',
    ))

SECRET_KEY: random long string
USERNAME and PASSWORD you want set for login
GOOGLE_SHEET_KEY: found in url of the google sheet you are using
JSON_KEYFILE_NAME: point to the json file you downloaded from google api, this is used by oauth lib
